### PR TITLE
Don't bound TLS ClientHello record size.

### DIFF
--- a/gatling.c
+++ b/gatling.c
@@ -873,8 +873,7 @@ void do_sslaccept(int sock,struct http_data* h,int reading) {
       /* first packet must be handshake */
       if (buf[0]!=0x16 ||	/* content type: handshake */
 	  buf[1]>3 ||	/* version major */
-	  buf[2]>3 ||	/* version minor */
-	  buf[3]>2) {	/* length > 0x200 */
+	  buf[2]>3) {	/* version minor */
 	if (buf[0]!=0x80 ||
 	    buf[2]!=1 ||	/* Client Hello */
 	    buf[3]>3 ||	/* version major */


### PR DESCRIPTION
do_sslaccept rejects ClientHello records >= 768 bytes. However,
legitimate records can exceed this size.

See https://bugs.chromium.org/p/chromium/issues/detail?id=814731